### PR TITLE
Manage all timers in a single location, fixes #86

### DIFF
--- a/date/duration.js
+++ b/date/duration.js
@@ -22,6 +22,10 @@ class Duration {
     static ofSeconds(seconds) {
         return new Duration(seconds * 1000);
     }
+
+    static ofMillis(millis) {
+        return new Duration(millis);
+    }
 }
 
 function between(from, to) {

--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
   "shell-version": [
     "46", "47"
   ],
-  "version-name": "0.8.0",
+  "version-name": "0.8.1",
   "donations": {
     "paypal": "dmfs"
   },

--- a/ui/menuitem.js
+++ b/ui/menuitem.js
@@ -88,7 +88,7 @@ export var IdleMenuItem = GObject.registerClass(
             });
 
             let text;
-            if (snoozed_until) {
+            if (new Date() < snoozed_until) {
                 text = `Not working on an issue until ${hhmmTimeString(snoozed_until)} `
             }
             else {

--- a/ui/tooltip.js
+++ b/ui/tooltip.js
@@ -1,31 +1,31 @@
 import St from 'gi://St';
-import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import { Duration } from '../date/duration.js';
+import { managedTimer } from '../utils/utils.js';
 
 export var Tooltip = GObject.registerClass(
     class Tooltip extends St.Label {
         _init(actor, tooltip, timeout = 1000) {
-            super._init({text: tooltip, style_class: 'tooltip'});
+            super._init({ text: tooltip, style_class: 'tooltip' });
             this.hide();
             Main.layoutManager.uiGroup.add_child(this);
             Main.layoutManager.uiGroup.set_child_above_sibling(this, null);
             this.tooltip_timeout = null;
 
             actor.connect('enter-event', (actor, event) => {
-                this.tooltip_timeout = GLib.timeout_add(GLib.PRIORITY_DEFAULT, timeout,
+                this.tooltip_timeout = managedTimer(Duration.ofMillis(timeout),
                     () => {
                         // TODO: be smarter about the location of the tool tip, or use a system tooltip if there is any
                         let [x, y] = event.get_coords();
                         this.set_position(x, y);
                         this.show();
-                        this.tooltip_timeout = undefined;
-                        return GLib.SOURCE_REMOVE;
-                    });
+                    },
+                    "tooltip " + tooltip);
             });
 
             actor.connect('leave-event', () => {
-                this._remove_timeout();
+                this.tooltip_timeout?.();
                 this.hide();
             });
 
@@ -34,15 +34,8 @@ export var Tooltip = GObject.registerClass(
             });
         }
 
-        _remove_timeout() {
-            if (this.tooltip_timeout) {
-                GLib.Source.remove(this.tooltip_timeout);
-                this.tooltip_timeout = null;
-            }
-        }
-
         destroy() {
-            this._remove_timeout();
+            this.tooltip_timeout?.();
             Main.layoutManager.uiGroup.remove_child(this);
             super.destroy();
         }

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -2,19 +2,35 @@ import GLib from 'gi://GLib';
 import { debug } from './log.js';
 
 /*
- * A Set to keep track of all open timers. We use this to remove them in one go when we get disposed.
+ * A Map to keep track of all open timers. We use this to remove them in one go when we get disposed.
  */
-const timers = new Set();
+const timers = new Map();
 
-async function timeout(delay) {
+async function timeout(delay, label) {
     return new Promise((resolve, reject) => {
-        const timer = GLib.timeout_add(GLib.PRIORITY_DEFAULT, delay.toMillis(), () => {
-            timers.delete(timer)
+        let timer = GLib.timeout_add(GLib.PRIORITY_DEFAULT, delay.toMillis(), () => {
+            timer = unregisterTimer(timer, "async");
             resolve();
             return GLib.SOURCE_REMOVE;
         })
-        timers.add(timer);
+        registerTimer(timer, "async", label);
     });
+}
+
+/**
+ * Calls the given callback after the given duration.
+ * This timeout can be cancelled by calling the returned function.
+ */
+function managedTimer(delay, callback, label) {
+    let timer = GLib.timeout_add(GLib.PRIORITY_DEFAULT, delay.toMillis(), () => {
+        timer = unregisterTimer(timer, "managed");
+        callback?.();
+        return GLib.SOURCE_REMOVE;
+    });
+    registerTimer(timer, "managed", label);
+    return () => {
+        timer = removeTimer(timer, "managed");
+    }
 }
 
 /**
@@ -22,26 +38,22 @@ async function timeout(delay) {
  *
  * The method returns a function that servers as the temrination handle and stops the interval when called.
  */
-function interval(initial_delay, interval, callback) {
-    let timeout = GLib.timeout_add(GLib.PRIORITY_DEFAULT, initial_delay.toMillis(), () => {
-        timers.delete(timeout);
-        timeout = GLib.timeout_add(GLib.PRIORITY_DEFAULT, interval.toMillis(), () => {
+function interval(initial_delay, interval, callback, label) {
+    let timer = GLib.timeout_add(GLib.PRIORITY_DEFAULT, initial_delay.toMillis(), () => {
+        unregisterTimer(timer, "interval");
+        timer = GLib.timeout_add(GLib.PRIORITY_DEFAULT, interval.toMillis(), () => {
             callback?.()
             return GLib.SOURCE_CONTINUE;
         });
         callback?.()
-        timers.add(timeout);
+        registerTimer(timer, "interval", label);
         return GLib.SOURCE_REMOVE;
     });
 
-    timers.add(timeout);
+    registerTimer(timer, "interval", label);
 
     return () => {
-        if (timeout) {
-            timers.delete(timeout);
-            GLib.Source.remove(timeout);
-            timeout = undefined;
-        }
+        timer = removeTimer(timer, "interval")
     };
 }
 
@@ -55,16 +67,37 @@ async function retrying(promise, count, delay) {
             if (++attempts >= count) {
                 throw new Error("Max retries reached");
             }
-            await timeout(delay);
+            await timeout(delay, "async retrying");
         }
     }
 }
 
 function destroy() {
-    for (const timer of timers) {
-        GLib.Source.remove(timer);
-        timers.delete(timer);
+    for (const [timer, label] of timers) {
+        removeTimer(timer)
     }
 }
 
-export { retrying, interval, timeout, destroy }
+function removeTimer(timer, timer_type) {
+    if (timer) {
+        debug("remove", timer_type, "timer", timer)
+        GLib.Source.remove(timer);
+        unregisterTimer(timer, timer_type);
+    }
+}
+
+function unregisterTimer(timer, timer_type) {
+    if (timer) {
+        debug("unregister", timer_type, "timer", timer, timers.get(timer))
+        timers.delete(timer);
+        debug("remaining timers ", JSON.stringify([...timers]))
+    }
+}
+
+function registerTimer(timer, timer_type, label) {
+    debug("register", timer_type, "timer", timer, label)
+    timers.set(timer, label);
+}
+
+
+export { retrying, interval, timeout, managedTimer, destroy }


### PR DESCRIPTION
This commit moves all timer management into `utils.js`. This ensures we have no stale timers after the plugin is disabled and it should fix all remaining notifaction and worklog timer issues.